### PR TITLE
Fix RemovedInDjango40Warning for middleware get_resopnse()

### DIFF
--- a/rest_framework/authentication.py
+++ b/rest_framework/authentication.py
@@ -136,7 +136,10 @@ class SessionAuthentication(BaseAuthentication):
         """
         Enforce CSRF validation for session based authentication.
         """
-        check = CSRFCheck()
+        def dummy_get_response(request):  # pragma: no cover
+            return None
+
+        check = CSRFCheck(dummy_get_response)
         # populates request.META['CSRF_COOKIE'], which is used in process_view()
         check.process_request(request)
         reason = check.process_view(request, None, (), {})

--- a/tests/test_request.py
+++ b/tests/test_request.py
@@ -205,8 +205,12 @@ class TestUserSetter(TestCase):
         # available to login and logout functions
         self.wrapped_request = factory.get('/')
         self.request = Request(self.wrapped_request)
-        SessionMiddleware().process_request(self.wrapped_request)
-        AuthenticationMiddleware().process_request(self.wrapped_request)
+
+        def dummy_get_response(request):  # pragma: no cover
+            return None
+
+        SessionMiddleware(dummy_get_response).process_request(self.wrapped_request)
+        AuthenticationMiddleware(dummy_get_response).process_request(self.wrapped_request)
 
         User.objects.create_user('ringo', 'starr@thebeatles.com', 'yellow')
         self.user = authenticate(username='ringo', password='yellow')


### PR DESCRIPTION
Fixes #7417.

Fixes all these issues seen with `tox -e py38-django31`:

```
  /Users/chainz/Documents/Projects/django-rest-framework/tests/test_request.py:208: RemovedInDjango40Warning: Passing None for the middleware get_response argument is deprecated.
    SessionMiddleware().process_request(self.wrapped_request)

tests/test_requests_client.py: 1 test with warning
tests/test_testing.py: 4 tests with warnings
tests/test_throttling.py: 1 test with warning
tests/authentication/test_authentication.py: 4 tests with warnings
tests/browsable_api/test_browsable_api.py: 4 tests with warnings
  /Users/chainz/Documents/Projects/django-rest-framework/rest_framework/authentication.py:139: RemovedInDjango40Warning: Passing None for the middleware get_response argument is deprecated.
    check = CSRFCheck()
```

*Note*: Before submitting this pull request, please review our [contributing guidelines](https://github.com/encode/django-rest-framework/blob/master/CONTRIBUTING.md#pull-requests).

## Description

Please describe your pull request. If it fixes a bug or resolves a feature request, be sure to link to that issue. When linking to an issue, please use `refs #...` in the description of the pull request.
